### PR TITLE
Change reasoning heuristic to use Inspect reasoning settings

### DIFF
--- a/src/ucb/agents/agents.py
+++ b/src/ucb/agents/agents.py
@@ -133,7 +133,7 @@ def agent(
     reasoning_model = _is_reasoning_model()
 
     if not reasoning_model:
-        sys_msg += "\n" + REASONING_INSTRUCTIONS
+        sys_msg += "\n\n" + REASONING_INSTRUCTIONS
 
     tools = _make_tool_list(
         timeout=timeout,

--- a/src/ucb/agents/utils.py
+++ b/src/ucb/agents/utils.py
@@ -206,6 +206,12 @@ def _is_reasoning_model() -> bool:
     Is the current model a reasoning/thinking model?
     """
     model = get_model()
+    if model.name == "none":
+        logger.warning(
+            f"Could not determine reasoning level of model {model}. Assuming non-reasoning."
+        )
+        return False
+
     if isinstance(model.api, OpenAIAPI):
         # All OpenAI o-series models think, no other reasoning models do.
         return model.api.is_o_series()

--- a/src/ucb/agents/utils.py
+++ b/src/ucb/agents/utils.py
@@ -213,8 +213,10 @@ def _is_reasoning_model() -> bool:
     # We cannot do a similar check for Anthropic because 3.7 Sonnet can either
     # use thinking or not depending on the arguments passed to it.
 
-
-    if model.config.reasoning_effort is not None or model.config.reasoning_tokens is not None:
+    if (
+        model.config.reasoning_effort is not None
+        or model.config.reasoning_tokens is not None
+    ):
         logger.warning(
             "Model config has reasoning_effort or reasoning_tokens set. Assuming reasoning model."
         )


### PR DESCRIPTION
## Summary

Using providers other than Anthropic or OpenAI will cause exceptions to be thrown. In addition, the Anthropic heuristic only checked for models other than Claude 3 and 3.5 for reasoning models, and 3.7 optionally reasons.

This shifts it so that OpenAI o-series models continue to be detected as reasoning (as you cannot disable reasoning for them), but other models will be classified as reasoning or non-reasoning based on the presence of `reasoning_effort` or `reasoning_tokens` in their `GenerateConfig`.

The way this can go wrong is that you can pass those reasoning effort/tokens parameters even if they are unused by the provider, causing incorrect detection of models as reasoning or non reasoning. Hence, I have added a warning.