### PR TITLE
Pin `angr` dep

### DIFF
--- a/src/ucb/containers/agent/requirements.txt
+++ b/src/ucb/containers/agent/requirements.txt
@@ -20,7 +20,7 @@ aiohappyeyeballs
 aiohttp
 aioquic
 aiosignal
-angr
+angr==9.2.154
 archinfo
 asgiref
 attrs


### PR DESCRIPTION
In the past few days, `ucb build` runs into an error because `angr` doesn't have a suitable wheel found. It tries to build from source and fails to find a Rust compiler, so it throws an error.

Looking at [the PyPI history](https://pypi.org/project/angr/9.2.154/#history), two recent changes are at fault. Pinning to the version from early May fixes it.

## Test Plan
Run `ucb build` before and after changes, see it is broken and then gets fixed by these changes.