### PR TITLE
Fix package build configuration for proper module inclusion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ package-dir = {"" = "src"}
 
 [tool.setuptools.packages.find]
 where = ["src"]
-include = ["ucb", "ucb.inspect", "ucb.containers.agent"]
+include = ["ucb*"]
 
 [tool.setuptools.package-data]
 "ucb" = [
@@ -102,8 +102,7 @@ include = ["ucb", "ucb.inspect", "ucb.containers.agent"]
     "containers/*.yml",
     "containers/agent/**",
     "containers/gaas/**",
-    "challenges/**/.env", # Used for cve-bench
-    "challenges/**/",
+    "benchmarks/**",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "idna>=3.10",
     "ijson>=3.3.0",
     "inspect-ai>=0.3.93",
-    "inspect-cyber",
+    "inspect-cyber @ git+https://github.com/UKGovernmentBEIS/inspect_cyber.git",
     "jiter>=0.8.2",
     "jmespath>=1.0.1",
     "jsonlines>=4.0.0",
@@ -122,6 +122,3 @@ replace = "version='{new_version}'"
 filename = "pyproject.toml"
 search = "version = \"{current_version}\""
 replace = "version = \"{new_version}\""
-
-[tool.uv.sources]
-inspect-cyber = { git = "https://github.com/UKGovernmentBEIS/inspect_cyber.git" }


### PR DESCRIPTION
## Summary
- Update packages.find to include all ucb subpackages with wildcard pattern
- Fix package-data paths to reference actual benchmarks directory instead of non-existent challenges directory
- Ensures all Python modules (agents, tasks) and data files are properly bundled when package is installed

🤖 Generated with [Claude Code](https://claude.ai/code)

Michael's note: I also needed to fix inspect-cyber so it installed properly in dependencies automatically.

## Test Plan

Install this in another repo, see that running `ucb` evals no longer fails, verify full inspect-cyber is installed